### PR TITLE
Fix: Correct broken links to the user page

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@ inicializarModoOscuro();
     <p class="text-base sm:text-lg mb-2"><strong>Raudy Barbershop y Sport</strong></p>
     <p class="text-base sm:text-lg mb-6">Gestiona tus turnos de manera fácil y rápida.</p>
 
-    <a href="usuario_main.html" class="bg-white dark:bg-gray-200 text-blue-900 dark:text-blue-800 font-semibold px-6 py-3 rounded-xl shadow-lg hover:bg-gray-100 dark:hover:bg-gray-300 transition block w-full sm:w-auto mx-auto">
+    <a href="usuario.html" class="bg-white dark:bg-gray-200 text-blue-900 dark:text-blue-800 font-semibold px-6 py-3 rounded-xl shadow-lg hover:bg-gray-100 dark:hover:bg-gray-300 transition block w-full sm:w-auto mx-auto">
       Ver turnos
     </a>
   </section>

--- a/index_main.html
+++ b/index_main.html
@@ -63,7 +63,7 @@ inicializarModoOscuro();
     <p class="text-base sm:text-lg mb-2"><strong>Raudy Barbershop y Sport</strong></p>
     <p class="text-base sm:text-lg mb-6">Gestiona tus turnos de manera fácil y rápida.</p>
 
-    <a href="usuario_main.html" class="bg-white dark:bg-gray-200 text-blue-900 dark:text-blue-800 font-semibold px-6 py-3 rounded-xl shadow-lg hover:bg-gray-100 dark:hover:bg-gray-300 transition block w-full sm:w-auto mx-auto">
+    <a href="usuario.html" class="bg-white dark:bg-gray-200 text-blue-900 dark:text-blue-800 font-semibold px-6 py-3 rounded-xl shadow-lg hover:bg-gray-100 dark:hover:bg-gray-300 transition block w-full sm:w-auto mx-auto">
       Ver turnos
     </a>
   </section>

--- a/negocio_main.html
+++ b/negocio_main.html
@@ -62,7 +62,7 @@
             </svg>
             Configuración
           </a>
-          <a href="usuario_main.html" class="sidebar-link">
+          <a href="usuario.html" class="sidebar-link">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
             </svg>


### PR DESCRIPTION
Several pages (`index.html`, `index_main.html`, and `negocio_main.html`) were linking to `usuario_main.html` instead of `usuario.html`.

The `vite.config.js` file is configured to build `usuario_main.html` as `usuario.html`, which caused a 404 error when the links were pointing to the source filename in a production build.

This commit corrects the links to point to `usuario.html`, ensuring that the user page is accessible in both development and production environments.